### PR TITLE
checkvolstatus: Make sure each brick is online

### DIFF
--- a/userparams/glubix_checkvolstatus.pl
+++ b/userparams/glubix_checkvolstatus.pl
@@ -31,21 +31,29 @@ my $result = `$exec_cmd`;
 if ($result =~ m/Status: Started/) {
 	# volume status is Started
 	$rc = 1;
+	# Now parse the result of gluster volume status command
+	# Sample output:
+	# # gluster volume status test-volume
+	# Status of volume: test-volume
+	# Gluster process                        Port    Online   Pid
+	# ------------------------------------------------------------
+	# Brick arch:/export/rep1                24010   Y       18474
+	# Brick arch:/export/rep2                24011   Y       18479
+	# NFS Server on localhost                38467   Y       18486
+	# Self-heal Daemon on localhost          N/A     Y       18491
 
 	if ($gluster_volume_numbricks ne "" && $gluster_volume_numbricks > 0) {
-		my $exec_cmd2 = "$gluster_cmd volume status $gluster_volume_name 2> /dev/null | grep '^Brick' | wc -l";
+		my $exec_cmd2 = "$gluster_cmd volume status $gluster_volume_name 2> /dev/null | grep '^Brick'";
 		my $result2 = `$exec_cmd2`;
-
-	 	my $num_active_brick = $result2;
-
-		# If number of active bricks were less than $gluster_volume_numbricks. return code is 0;
-		if( $num_active_brick < $gluster_volume_numbricks ) {
-			# missing some bricks. may be down.
-			$rc = 0;
-		} else {
-			# brick is healthy
-			$rc = 1;
+		my $online_bricks = 0;
+		for ( split /^/, $result2 ) {
+			my @stat = split;
+			if ( $stat[-2] != 'Y' ) {
+				last;
+			}
+			$online_bricks++;
 		}
+		$rc = ($online_bricks == $gluster_volume_numbricks) ? 1 : 0;
 	}
 } elsif ($result =~ m/Status: Stopped/) {
 	# volume status is Stopped


### PR DESCRIPTION
Fix a bug that a brick online status was not checked so a volume was falsely inspected as normal when a volume had offline bricks.
